### PR TITLE
Replace hardcoded strings with variables from config.R

### DIFF
--- a/rbind_cluster_county_test.R
+++ b/rbind_cluster_county_test.R
@@ -10,12 +10,12 @@ library(sqldf)
 library(dplyr)
 registerDoMC(21)
 
-#source here indicates that we can reuse some functions that were written in other script
-source("/gpfs/data1/cmongp/lansong/cec_lan/cec_utils.R")# some functions will be used in this script
-source("/gpfs/data1/cmongp/lansong/cec_lan/config.R")#for set up the working directory
-source("/gpfs/data1/cmongp/lansong/cec_lan/forest_type.R")# useless
-source("/gpfs/data1/cmongp/lansong/cec_lan/data.R")# useless
-source("/gpfs/data1/cmongp/lansong/cec_lan/cluster_results_new.R")#useless
+# source here indicates that we can reuse some functions that were written in other scripts stored in the shared folder.
+source("shared/cec_utils.R")# some functions will be used in this script
+source("shared/config.R")# set up the working directory and expose root_dir and data_dir variables
+source("shared/forest_type.R")# useless
+source("shared/data.R")# useless
+source("shared/cluster_results_new.R")#useless
 
 # loads F3 forest, elevation, sit raster,stack all F3 forest data with sit data,and chwrite.csv(final_csv,"/gpfs/data1/cmongp/lansong/cec_lan/Sierra_Navada_Clusters/final_csvs/county_csv/Sorted_Sierra_Nevada.csv")ange the variable name to simple name
 load_forest_data <- function(){
@@ -35,7 +35,7 @@ load_forest_data <- function(){
 # write elevation data for the counties in whole Sierra Nevada and extract the values of biomass from F3 data, write elevation, county name, and biomass values for all the pixels in Sierra Nevada
 write_ele_biomass_in_county = function(){
   log("read the forest elevation in whole Sierra Nevada")
-  fl.ele.mask <<-raster("/gpfs/data1/cmongp/lansong/cec_lan/Sierra_Navada_Clusters/new_test/fl_ele_Sierra.tif")# this is the new forest elevation data in Sierra Nevada without excluding NPS and Wildeness area. the white areas indicate the no data(no biomass)
+  fl.ele.mask <<-raster(file.path(root_dir, "Sierra_Navada_Clusters/new_test/fl_ele_Sierra.tif"))# this is the new forest elevation data in Sierra Nevada without excluding NPS and Wildeness area. the white areas indicate the no data(no biomass)
   df.ele <<- rasterToPoints(fl.ele.mask, spatial=T)#total number70857636
   
   log("read the shapefile of county boundary of Sierra Nevada")

--- a/rbind_cluster_county_test.R
+++ b/rbind_cluster_county_test.R
@@ -39,7 +39,7 @@ write_ele_biomass_in_county = function(){
   df.ele <<- rasterToPoints(fl.ele.mask, spatial=T)#total number70857636
   
   log("read the shapefile of county boundary of Sierra Nevada")
-  shp <<- shapefile("/gpfs/data1/cmongp/ujjwal/cec/Forest Data/CA_Counties/CA_Sierra_TIGER2016.shp")#this is county boundary shapefile
+  shp <<- shapefile(file.path(data_dir, "CA_Counties/CA_Sierra_TIGER2016.shp"))#this is county boundary shapefile
   shp.curr_county.prj <- spTransform(shp, proj4string(fl.ele))#convert to the same project 
   
   log("Getting county's elevation data for Whole Sierra")

--- a/rbind_cluster_county_test.R
+++ b/rbind_cluster_county_test.R
@@ -17,7 +17,7 @@ source("shared/forest_type.R")# useless
 source("shared/data.R")# useless
 source("shared/cluster_results_new.R")#useless
 
-# loads F3 forest, elevation, sit raster,stack all F3 forest data with sit data,and chwrite.csv(final_csv,"/gpfs/data1/cmongp/lansong/cec_lan/Sierra_Navada_Clusters/final_csvs/county_csv/Sorted_Sierra_Nevada.csv")ange the variable name to simple name
+# loads F3 forest, elevation, sit raster,stack all F3 forest data with sit data,and write final_csv to Sorted_Sierra_Nevada.csv") and change the variable name to simple name
 load_forest_data <- function(){
   log("loading forest data")
   fl <<- list.files(pattern=glob2rx("Total*.tif$")) # list all the F3 Data  There are total of 60 files 
@@ -56,7 +56,7 @@ write_ele_biomass_in_county = function(){
   F3_ele_biomass_df=as.data.frame(df.data.curr_county.latlon)
   
   log("Writing into csv file")
-  directory <- paste("/gpfs/data1/cmongp/lansong/cec_lan/Sierra_Navada_Clusters/final_csvs")
+  directory <- paste(file.path(root_dir, "Sierra_Navada_Clusters/final_csvs"))
   write.csv(F3_ele_biomass_df, paste(directory,"/F3_ele_biomass.csv",sep = ""))#this table includes the elevation,county name,a bunch of variables realted to biomass.
 }
 
@@ -73,7 +73,7 @@ main()
 #running the rest of code to join the pixel data with cluster data and forest type data
 
 print("reading the table produced in the function of write_ele_biomass_in_county")
-fl_sierra=read.csv("/gpfs/data1/cmongp/lansong/cec_lan/Sierra_Navada_Clusters/final_csvs/F3_ele_biomass.csv")#here I read the csv file we create in the fuction of write_ele_biomass_in_county. if you didn't write csv in the second function, you can directly use the variable name F3_ele_biomass_df
+fl_sierra=read.csv(file.path(root_dir, "Sierra_Navada_Clusters/final_csvs/F3_ele_biomass.csv"))#here I read the csv file we create in the fuction of write_ele_biomass_in_county. if you didn't write csv in the second function, you can directly use the variable name F3_ele_biomass_df
 fl_sierra[is.na(fl_sierra)]=0 
 #change the column name
 colnames(fl_sierra)[2]="elevation"
@@ -83,10 +83,10 @@ colnames(fl_sierra)[67]="lng"
 colnames(fl_sierra)[68]="lat"
 #read the forest type csv this is another information realted to forst type needed to add to the dataframe
 print("reading the forest type table in Whole Sierra")
-forest_type=read.csv("/gpfs/data1/cmongp/lansong/cec_lan/Sierra_Navada_Clusters/final_csvs/forest_type_Sierra_wgs.csv")
+forest_type=read.csv(file.path(root_dir, "Sierra_Navada_Clusters/final_csvs/forest_type_Sierra_wgs.csv"))
 #read the shapefile of the cluster in whole Sierra
 print("reading the cluster in whole Sierra ") #read the cluster results for whole sierra Neveda that we created in ArcMap
-Sierra_grid_cluster=shapefile("/gpfs/data1/cmongp/lansong/cec_lan/Sierra_Navada_Clusters/new_test/cluster_final_Sierra.shp")
+Sierra_grid_cluster=shapefile(file.path(root_dir, "Sierra_Navada_Clusters/new_test/cluster_final_Sierra.shp"))
 
 #list a total of 21 counties in Sierra Nevada
 counties=c("Alpine","Yuba","Inyo","Madera","Mariposa","Tehama","Calaveras","Nevada","Shasta","Plumas","Lassen","Sierra","Placer","Butte","Amador","El Dorado","Tulare","Tuolumne","Mono","Fresno","Kern")
@@ -139,4 +139,4 @@ results=foreach(county_name=counties)%dopar%{#parally processing the pixel data 
 results_final=do.call(rbind,results)#combine the pixel associated with each county
 print("write the csv")
 final_csv=arrange(results_final, desc(as.numeric(as.character(cluster_no))))#I changed this code
-write.csv(final_csv,"/gpfs/data1/cmongp/lansong/cec_lan/Sierra_Navada_Clusters/final_csvs/county_csv/Sorted_Sierra_Nevada.csv")
+write.csv(final_csv,file.path(root_dir, "Sierra_Navada_Clusters/final_csvs/county_csv/Sorted_Sierra_Nevada.csv"))

--- a/shared/config.R
+++ b/shared/config.R
@@ -5,7 +5,6 @@ load_libraries <- function(){
   library(rgdal)
   library(parallel)
   library(maptools)
-  library(foreign)
  
 }
 
@@ -15,7 +14,5 @@ data_dir ="/gpfs/data1/cmongp/ujjwal/cec/Forest Data/" # This is the directory w
 setup <- function(num_clusters=10){
   load_libraries()
   rasterOptions(maxmemory = 10e+9, chunksize = 10e+08) # comment this out if the machine is not powerful enough
-  setwd("/gpfs/data1/cmongp/ujjwal/cec/Forest Data/")# set to your own directory, which your data is located 
+  setwd(data_dir)# set to your own directory, which your data is located 
 }
-
-


### PR DESCRIPTION
config.R returns `root_dir` and `data_dir`.  For every instance of those two directories that were hardcoded in the cluster script, I replaced them with `file(var_dir, "rest_of_path")` so now we only need to change the path in the config file.

Also changed the `source` helpers to just use a relative path since they are all part of the same repo.  